### PR TITLE
attachment texture fix

### DIFF
--- a/VanillaVariants/assets/vanvar/itemtypes/wearable/hooved.json
+++ b/VanillaVariants/assets/vanvar/itemtypes/wearable/hooved.json
@@ -14,13 +14,16 @@
     ],
     "attributes": {
         "attachableToEntity": {
+            "texturePrefixCode": "hoovedwearables-{category}-{type}-{color}",
             "categoryCodeByType": {
                 "*-head-bridle*": "bridle",
                 "*-middleback-saddle1*": "saddle",
                 "*-lowerbackside-saddlebags*": "sidebags"
             },
             "attachedShapeBySlotCode": {
-                "*": { "base": "game:item/wearable/hooved/{type}-elk" }
+                "head": { "base": "game:item/wearable/hooved/{type}-elk" },
+                "middleback": { "base": "game:item/wearable/hooved/{type}-elk" },
+                "lowerbackside": { "base": "game:item/wearable/hooved/{type}-elk" }
             }
         },
         "controlSchemeByType": {


### PR DESCRIPTION
fixed elk attachment textures overwriting each other and made patching in shapes for mount mods easier.