### PR TITLE
add the groupby attribute to toggles since they didn't already have them

### DIFF
--- a/VanillaVariants/assets/vanvar/blocktypes/wood/mechanics/toggle.json
+++ b/VanillaVariants/assets/vanvar/blocktypes/wood/mechanics/toggle.json
@@ -16,6 +16,9 @@
         },
         { "name": "NWOrientable" }
     ],
+    "attributes": {
+        "handbook": { "groupBy": ["woodentoggle-*"] }
+    },
     "creativeinventory": {
         "general": ["*-ns"],
         "mechanics": ["*-ns"],


### PR DESCRIPTION
As title, corrects this:
<img width="1208" height="491" alt="image" src="https://github.com/user-attachments/assets/d73a3d2f-9266-41fc-883d-21a52fbfe073" />
